### PR TITLE
Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --save rn-geolocation
 
 In your settings.gradle replace ```include ':app'``` with:
 ```
-include 'rn-geolocation',':app'
+include ':rn-geolocation',':app'
 project(':rn-geolocation').projectDir = new File(rootProject.projectDir, '../node_modules/rn-geolocation/android')
 ```
 In your android/app/build.gradle add:


### PR DESCRIPTION
A one-character fix, just to save time for people copy/pasting the installation instructions.
